### PR TITLE
Fixed minor error in t/packages.lisp

### DIFF
--- a/t/packages.lisp
+++ b/t/packages.lisp
@@ -8,6 +8,10 @@
 	:it.bese.FiveAM))
 
 (unless (5am:get-test :it.bese)
+  ;; define the suite
   (5am:def-suite :it.bese))
+;;if exists the suite called :it.bese
+(when (5am:get-test :it.bese)
+  (5am:def-suite :it.bese.yaclml :in :it.bese))
 
-(5am:def-suite :it.bese.yaclml :in :it.bese)
+


### PR DESCRIPTION
Hello, sure.
First I saw the error by quicklisp
According to http://report.quicklisp.org/2018-01-16/failure-report/yaclml.html#yaclml_test

Error
Unknown suite IT.BESE.

**:it.bese** is a test suite defined by
(unless (5am:get-test :it.bese)
  (5am:def-suite :it.bese))

There is a function called **5am:get-test**  that returns the test suite.
;; this code produces the error
;; Unknown suite IT.BESE.
(5am:def-suite :it.bese.yaclml :in :it.bese)

;; possible solution, could be.
(when (5am:get-test :it.bese)
  (5am:def-suite :it.bese.yaclml :in :it.bese))

If you add  "when" the code works fine.